### PR TITLE
MiBench: Drop riscv64 stats counters workaround

### DIFF
--- a/MultiSource/Benchmarks/MiBench/run_all.sh
+++ b/MultiSource/Benchmarks/MiBench/run_all.sh
@@ -111,8 +111,6 @@ case $CPU in
     ;;
     riscv64|riscv64-hybrid|riscv64-purecap)
     COUNT_STATS="minimal_count_stats --format csv"
-    # FIXME: counters currently broken due to ASR bug
-    COUNT_STATS="${COUNT_STATS} -e cycles -e time -e instret"
     ;;
     native)
     COUNT_STATS="time"


### PR DESCRIPTION
All counters now work on Toooba without ASR.